### PR TITLE
Rebuild 1.2.1 for gcc9

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -16,7 +16,6 @@ jobs:
         CONFIG: linux_64_fortran_compiler_version9
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-osx.yml
+++ b/.azure-pipelines/azure-pipelines-osx.yml
@@ -14,7 +14,6 @@ jobs:
       osx_64_fortran_compiler_version9:
         CONFIG: osx_64_fortran_compiler_version9
         UPLOAD_PACKAGES: 'True'
-    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.azure-pipelines/azure-pipelines-win.yml
+++ b/.azure-pipelines/azure-pipelines-win.yml
@@ -11,7 +11,6 @@ jobs:
       win_64_:
         CONFIG: win_64_
         UPLOAD_PACKAGES: 'True'
-    maxParallel: 4
   timeoutInMinutes: 360
   variables:
     CONDA_BLD_PATH: D:\\bld\\

--- a/.ci_support/linux_64_fortran_compiler_version7.yaml
+++ b/.ci_support/linux_64_fortran_compiler_version7.yaml
@@ -1,3 +1,5 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/.ci_support/linux_64_fortran_compiler_version9.yaml
+++ b/.ci_support/linux_64_fortran_compiler_version9.yaml
@@ -1,3 +1,5 @@
+cdt_name:
+- cos6
 channel_sources:
 - conda-forge,defaults
 channel_targets:

--- a/build-locally.py
+++ b/build-locally.py
@@ -61,7 +61,7 @@ def main(args=None):
         help="Setup debug environment using `conda debug`",
     )
     p.add_argument(
-        "--output-id", help="If running debug, specifiy the output to setup."
+        "--output-id", help="If running debug, specify the output to setup."
     )
 
     ns = p.parse_args(args=args)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ package:
 
 source:
   url: https://github.com/csdms/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: f22686dde4841977a8166a98de39d0357ded59824df1a6d2e0d38a98173b14d1
+  sha256: a03f3acaf9f29892a5b4c8cedb9860fb3852a5b36fdc16abf1c9c9ef1f533346
 
 build:
   number: 2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,5 @@
 {% set name = "bmi-fortran" %}
-{% set version = "1.2" %}
-{% set major = version.split('.')[0] %}
-{% set minor = version.split('.')[1] %}
+{% set version = "1.2.1" %}
 
 package:
   name: {{ name|lower }}
@@ -24,12 +22,12 @@ requirements:
 
 test:
   commands:
-    - test -f $PREFIX/include/bmif_{{ major }}_{{ minor }}.mod   # [unix]
-    - test -h $PREFIX/lib/libbmif$SHLIB_EXT                      # [unix]
-    - test -s $PREFIX/lib/libbmif.a                              # [unix]
-    - if not exist %LIBRARY_INC%\\bmif_{{ major }}_{{ minor }}.mod exit 1  # [win]
-    - if not exist %LIBRARY_LIB%\\bmif.lib exit 1                # [win]
-    - if not exist %LIBRARY_BIN%\\bmif_win.dll exit 1            # [win]
+    - test -f $PREFIX/include/bmif_1_2.mod             # [unix]
+    - test -h $PREFIX/lib/libbmif$SHLIB_EXT            # [unix]
+    - test -s $PREFIX/lib/libbmif.a                    # [unix]
+    - if not exist %LIBRARY_INC%\\bmif_1_2.mod exit 1  # [win]
+    - if not exist %LIBRARY_LIB%\\bmif.lib exit 1      # [win]
+    - if not exist %LIBRARY_BIN%\\bmif_win.dll exit 1  # [win]
 
 about:
   home: https://bmi.readthedocs.io

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bmi-fortran" %}
-{% set version = "2.0" %}
+{% set version = "1.2" %}
 {% set major = version.split('.')[0] %}
 {% set minor = version.split('.')[1] %}
 
@@ -12,7 +12,7 @@ source:
   sha256: f22686dde4841977a8166a98de39d0357ded59824df1a6d2e0d38a98173b14d1
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win and vc<14]
 
 requirements:


### PR DESCRIPTION
This PR builds bmi-fortran=1.2.1 using gcc/gfortran 9.3.0.
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
