### PR TITLE
Rebuild 2.0 for gcc9

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -11,11 +11,11 @@ jobs:
       linux_64_fortran_compiler_version7:
         CONFIG: linux_64_fortran_compiler_version7
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
       linux_64_fortran_compiler_version9:
         CONFIG: linux_64_fortran_compiler_version9
         UPLOAD_PACKAGES: 'True'
-        DOCKER_IMAGE: condaforge/linux-anvil-comp7
+        DOCKER_IMAGE: quay.io/condaforge/linux-anvil-comp7
   timeoutInMinutes: 360
 
   steps:

--- a/.ci_support/linux_64_fortran_compiler_version7.yaml
+++ b/.ci_support/linux_64_fortran_compiler_version7.yaml
@@ -5,7 +5,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/.ci_support/linux_64_fortran_compiler_version9.yaml
+++ b/.ci_support/linux_64_fortran_compiler_version9.yaml
@@ -5,7 +5,7 @@ channel_sources:
 channel_targets:
 - conda-forge main
 docker_image:
-- condaforge/linux-anvil-comp7
+- quay.io/condaforge/linux-anvil-comp7
 fortran_compiler:
 - gfortran
 fortran_compiler_version:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "bmi-fortran" %}
-{% set version = "1.2.1" %}
+{% set version = "2.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/csdms/{{ name }}/archive/v{{ version }}.tar.gz
-  sha256: a03f3acaf9f29892a5b4c8cedb9860fb3852a5b36fdc16abf1c9c9ef1f533346
+  sha256: f22686dde4841977a8166a98de39d0357ded59824df1a6d2e0d38a98173b14d1
 
 build:
-  number: 2
+  number: 1
   skip: true  # [win and vc<14]
 
 requirements:
@@ -22,10 +22,10 @@ requirements:
 
 test:
   commands:
-    - test -f $PREFIX/include/bmif_1_2.mod             # [unix]
+    - test -f $PREFIX/include/bmif_2_0.mod             # [unix]
     - test -h $PREFIX/lib/libbmif$SHLIB_EXT            # [unix]
     - test -s $PREFIX/lib/libbmif.a                    # [unix]
-    - if not exist %LIBRARY_INC%\\bmif_1_2.mod exit 1  # [win]
+    - if not exist %LIBRARY_INC%\\bmif_2_0.mod exit 1  # [win]
     - if not exist %LIBRARY_LIB%\\bmif.lib exit 1      # [win]
     - if not exist %LIBRARY_BIN%\\bmif_win.dll exit 1  # [win]
 


### PR DESCRIPTION
This PR builds bmi-fortran=2.0 using gcc/gfortran 9.3.0.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
